### PR TITLE
Dog should inherit from an abstract class

### DIFF
--- a/app/models/dog.rb
+++ b/app/models/dog.rb
@@ -1,3 +1,2 @@
-class Dog < ApplicationRecord
-  establish_connection :secondary
+class Dog < SecondaryBase
 end

--- a/app/models/secondary_base.rb
+++ b/app/models/secondary_base.rb
@@ -1,0 +1,5 @@
+class SecondaryBase < ApplicationRecord
+  self.abstract_class = true
+
+  connects_to database: { writing: :secondary }
+end


### PR DESCRIPTION
You want Dog to be a class that inherits from the class that establishes
the connection rather than establish the connection itself.

The reason for this is that as you add more models/tables you want only one
open connection not a connection for each model.